### PR TITLE
fixing modify protocol display

### DIFF
--- a/force-app/main/default/classes/TreatmentSessionLWCController.cls
+++ b/force-app/main/default/classes/TreatmentSessionLWCController.cls
@@ -183,7 +183,17 @@ public with sharing class TreatmentSessionLWCController {
 
     private static List<List<Protocol__c>> getUnassignedProtocols(Set<Id> protocolIdsToExclude){
         Map<String, Protocol__c[]> protocolsMap = new Map<String, Protocol__c[]>();
-        for(Protocol__c protocol : [SELECT Id, Name, Protocol_Categories__c FROM Protocol__c WHERE IsActive__c = true AND Id NOT IN :protocolIdsToExclude ORDER BY Protocol_Categories__c ASC, Name ASC]){
+        Set<Id> masterBundleProtocolIds = new Set<Id>();
+        for(Bundle_Entry__c entry : [
+            SELECT Id, Protocol__c
+            FROM Bundle_Entry__c 
+            WHERE Treatment_Bundle__r.IsActive__c = true 
+            AND Treatment_Bundle__r.IsMaster__c = true
+            AND Protocol__c NOT IN: protocolIdsToExclude
+        ]){
+            masterBundleProtocolIds.add(entry.Protocol__c);
+        }
+        for(Protocol__c protocol : [SELECT Id, Name, Protocol_Categories__c FROM Protocol__c WHERE Id IN :masterBundleProtocolIds ORDER BY Protocol_Categories__c ASC, Name ASC]){
             if(protocolsMap.containsKey(protocol.Protocol_Categories__c)){
                 protocolsMap.get(protocol.Protocol_Categories__c).add(protocol);
             }

--- a/force-app/main/default/lwc/treatmentModifySessionProtocol/treatmentModifySessionProtocol.html
+++ b/force-app/main/default/lwc/treatmentModifySessionProtocol/treatmentModifySessionProtocol.html
@@ -24,13 +24,14 @@
                     </template>
                 </div>
                 <div class="slds-col slds-size_1-of-6 slds-medium-size_2-of-12 slds-large-size_2-of-12">
-                    <template if:true={canRemoveProtocol}>
-                        <lightning-input 
+                    <template if:false={isSessionProtocol}>
+                        <lightning-input
                             type="toggle"
                             checked={notRemovedValue}
                             message-toggle-active='Assigned'
                             message-toggle-inactive='Removed'
                             onchange={toggleIsRemoved}
+                            disabled={disableToggle}
                             >
                         </lightning-input>
                     </template>

--- a/force-app/main/default/lwc/treatmentModifySessionProtocol/treatmentModifySessionProtocol.js
+++ b/force-app/main/default/lwc/treatmentModifySessionProtocol/treatmentModifySessionProtocol.js
@@ -105,8 +105,8 @@ export default class TreatmentModifySessionProtocol extends LightningElement {
         
     }
 
-    get canRemoveProtocol(){
-        return hasRemoveFromPlanPermission;
+    get disableToggle(){
+        return !hasRemoveFromPlanPermission;
     }
 
     get boxClass(){


### PR DESCRIPTION
Now showing disabled toggle when user doesn't have access to remove protocol from plan.

Fixed query for Unassigned protocols to include all protocols assigned to the Master Bundle.