### PR TITLE
TreatmentPriorityToDoList TreatmentPriority editable

### DIFF
--- a/force-app/main/default/classes/controller/TreatmentToDoListController.cls
+++ b/force-app/main/default/classes/controller/TreatmentToDoListController.cls
@@ -11,4 +11,31 @@ public with sharing class TreatmentToDoListController {
                 ORDER BY Id];
         return treatmentPlans;
     }
+
+    @AuraEnabled(cacheable=false)
+    public static void updateTreatment(ID recordId, Map<String, Object> fieldMap){
+        sObject sObj = cloneRecord(recordId);
+        for(String field : fieldMap.keySet()){
+            sObj.put(field, fieldMap.get(field));
+        }
+        insert sObj;
+    }
+
+    public static SObject cloneRecord(ID recordId){
+        DescribeSObjectResult describeResult = recordId.getSObjectType().getDescribe();
+        List<String> fieldNames = new List<String>( describeResult.fields.getMap().keySet() );
+        String query =
+        ' SELECT ' +
+            String.join( fieldNames, ',' ) +
+        ' FROM ' +
+            describeResult.getName() +
+        ' WHERE ' +
+            ' id = :recordId ' +
+        ' LIMIT 1 '
+        ;
+        SObject record = Database.query( query );
+        sObject sObj = Schema.getGlobalDescribe().get(describeResult.getName()).newSObject();
+        sObj = record.clone();
+        return sObj;
+    }
 }

--- a/force-app/main/default/lwc/confirmationDialog/confirmationDialog.html
+++ b/force-app/main/default/lwc/confirmationDialog/confirmationDialog.html
@@ -1,0 +1,29 @@
+<template>
+    <lightning-card if:true={visible}>
+        <div class="slds-container_small">
+            <section role="dialog" tabindex="-1" aria-labelledby="modal-heading-01" aria-modal="true" aria-describedby="modal-content-id-1" class="slds-modal slds-fade-in-open">
+                <div class="slds-modal__container">
+                    <header class="slds-modal__header">
+                        <h2 id="modal-heading-01" class="slds-text-heading_medium slds-hyphenate">{title}</h2>
+                    </header>
+                    <div class="slds-modal__content slds-p-around_medium" id="modal-content-id-1">
+                        <p>{message}</p>
+                    </div>
+                    <footer class="slds-modal__footer">
+                        <lightning-button variant="neutral"
+                                          name="cancel"
+                                          label={cancelLabel}
+                                          title={cancelLabel}
+                                          onclick={handleClick} ></lightning-button>
+                        <lightning-button variant="brand"
+                                          name="confirm"
+                                          label={confirmLabel}
+                                          title={confirmLabel}
+                                          onclick={handleClick} ></lightning-button>
+                    </footer>
+                </div>
+            </section>
+            <div class="slds-backdrop slds-backdrop_open"></div>
+        </div>
+    </lightning-card>
+</template>

--- a/force-app/main/default/lwc/confirmationDialog/confirmationDialog.js
+++ b/force-app/main/default/lwc/confirmationDialog/confirmationDialog.js
@@ -1,0 +1,23 @@
+import {LightningElement, api} from 'lwc';
+
+export default class ConfirmationDialog extends LightningElement {
+    @api visible; //used to hide/show dialog
+    @api title; //modal title
+    @api name; //reference name of the component
+    @api message; //modal message
+    @api confirmLabel; //confirm button label
+    @api cancelLabel; //cancel button label
+    @api originalMessage; //any event/message/detail to be published back to the parent component
+
+    //handles button clicks
+    handleClick(event){
+        //creates object which will be published to the parent component
+        let finalEvent = {
+            originalMessage: this.originalMessage,
+            status: event.target.name
+        };
+
+        //dispatch a 'click' event so the parent component can handle it
+        this.dispatchEvent(new CustomEvent('dlgclick', {detail: finalEvent}));
+    }
+}

--- a/force-app/main/default/lwc/confirmationDialog/confirmationDialog.js-meta.xml
+++ b/force-app/main/default/lwc/confirmationDialog/confirmationDialog.js-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>52.0</apiVersion>
+    <isExposed>false</isExposed>
+</LightningComponentBundle>

--- a/force-app/main/default/lwc/treatmentToDoSection/treatmentToDoSection.html
+++ b/force-app/main/default/lwc/treatmentToDoSection/treatmentToDoSection.html
@@ -17,10 +17,23 @@
         </div>
         <template if:true={expanded}>
             <div class="slds-col slds-size_1-of-1 slds-medium-size_2-of-12 slds-large-size_1-of-12">
-                <label class="slds-form-element__legend slds-form-element__label">Treatment Priority</label>
-                <div class="slds-form-element__static">
-                    <span>{animalTreatment.Treatment_Priority__c}</span>
-                </div>
+                <template if:true={isEdit}>
+                    <template if:true={treatmentPriorirtyPicklist.data}>
+                        <legend class="slds-form-element__legend slds-form-element__label">Treatment Priority</legend>
+                        <lightning-combobox name="treatmentPriority" label="Treatment Priority" variant="label-hidden" value={treatmentPriority}
+                            options={treatmentPriorirtyPicklist.data.values} onchange={handleTreatmentPriorityChange}>
+                        </lightning-combobox>
+                    </template>        
+                </template>
+                <template if:false={isEdit}>
+                    <label class="slds-form-element__legend slds-form-element__label">
+                        Treatment Priority
+                        <lightning-button-icon icon-name="utility:edit" variant="bare" onclick={handleEdit}></lightning-button-icon>
+                    </label>
+                    <div class="slds-form-element__static">
+                        <span>{animalTreatment.Treatment_Priority__c}</span>
+                    </div>
+                </template>
             </div>
             <div class="slds-col slds-size_1-of-1 slds-medium-size_2-of-12 slds-large-size_1-of-12" data-id='customlookupsearch'>
                 <template if:true={isEdit}>
@@ -116,6 +129,15 @@
                         label="Update"
                     ></lightning-button>
                 </div>
+            </template>
+            <template if:true={isConfirmationVisible}>
+                <c-confirmation-dialog title='Confirmation'
+                           message='This will create a new active treatment plan for this dog and will deactivate the current plan. Do you want to proceed?'
+                           confirm-label='Yes'
+                           cancel-label='No'
+                           visible={isConfirmationVisible}
+                           name="confirmModal"
+                           ondlgclick={handleConfirmationClick}></c-confirmation-dialog>
             </template>
             <template if:true={isSelected}>
                 <div class="slds-col slds-size_1-of-1">

--- a/force-app/main/default/test/test_TreatmentToDoListController.cls
+++ b/force-app/main/default/test/test_TreatmentToDoListController.cls
@@ -16,4 +16,13 @@ public with sharing class test_TreatmentToDoListController {
         Test.stopTest();
         System.assertEquals(0, treatmentPlans.size());
     }
+    
+    @isTest
+    static void updateAnimalTreatment() {
+        Treatment_Plan__c treatmentPlan = TestDataFactory.createPlan();
+        Test.startTest();
+        Map<String, Object> objMap = new Map<String, Object>{'Description__c'=> (Object)'Test'};
+        TreatmentToDoListController.updateTreatment(treatmentPlan.Id, objMap);
+        Test.stopTest();
+    }
 }


### PR DESCRIPTION
This change is regarding the Treatment priority to do list where treatment priority is editable and There is an pop up message that warns the user that if they proceed with updating the Treatment Bundle and Treatment priority  - this will create a new active treatment plan for this dog and will deactivate the current plan. The user must accept the message in order for the bundle to be updated.